### PR TITLE
Update gruntfile to copy source files into root crests folder

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,6 +4,22 @@ module.exports = function(grunt) {
 
     // Project configuration.
     grunt.initConfig({
+        copy: {
+            main: {
+                files: [
+                    {
+                        // Copy the source files directly into the build folder
+                        expand: true,
+                        cwd: 'source/crests/',
+                        src: ['*'], 
+                        dest: 'build/crests'
+                    }
+                ],
+                options: {
+                    timestamp: true
+                }
+            },
+        },
         image_resize: {
             resize120: {
                 options: {
@@ -59,5 +75,6 @@ module.exports = function(grunt) {
     });
 
     // Tasks
-    grunt.registerTask('default', ['image_resize', 'pngmin', 'aws_s3']);
+    grunt.registerTask('default', ['copy', 'image_resize', 'pngmin', 'aws_s3']);
+    
 };

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The source of all football assets used on The Guardian and scripts to easily com
 
 This requires ImageMagick, if you don't have it install with `brew install imagemagick`
 
-Then you'll need add your s3 keys. Duplicate/rename the `aws-keys.example.json` file to `aws-keys.json` and add your s3 keys.
+Make sure you have `frontend` Janus credentials.
 
 Get dependencies by running `npm install`. 
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "grunt-aws-s3": "^0.14.0",
-    "grunt-contrib-copy": "^0.8.1",
+    "grunt-contrib-copy": "^0.8.2",
     "grunt-image-resize": "^1.0.0",
     "grunt-pngmin": "^1.0.2"
   }


### PR DESCRIPTION
On dotcom we only use the /120 or /60 sizes of the compressed crests but apps use the source files compressed and resized by imgx - the gruntfile task did not take this into account and copy from source -> build therefore new crests were not available to the apps.

I have updated the grunt task to copy the files into the crests folder so new crests get uploaded to S3.

We should maybe be using imgx as well on dotcom and letting them serve the compressed and resized images, avoiding this build step and allowing us to build a simple S3 uploader tool that doesn't need dev input but in the meantime, this works.

@guardian/dotcom-platform @alexduf 