### PR TITLE
Add distinct tasks to `prepare` and `upload` assets

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,5 +76,8 @@ module.exports = function(grunt) {
 
     // Tasks
     grunt.registerTask('default', ['copy', 'image_resize', 'pngmin', 'aws_s3']);
+
+    grunt.registerTask('prepare', ['copy', 'image_resize', 'pngmin']);    
+    grunt.registerTask('upload', ['aws_s3']);
     
 };

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
+    "prepare": "grunt prepare",
+    "upload": "grunt upload",
     "deploy": "grunt"
   },
   "repository": {


### PR DESCRIPTION
## What does this change?

Split asset preparation and uploading into distinct tasks, so as to prevent someone (definitely not me) from having to rebuild all the assets if they forgot to get their janus token!

## How to test

`yarn prepare`, then `yarn upload`